### PR TITLE
cla-check: persist env in step before action

### DIFF
--- a/cla-check/action.yaml
+++ b/cla-check/action.yaml
@@ -11,12 +11,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: "Setup environment"
+      shell: "bash"
+      run: |
+        # Persist the env into future commands.
+        GITHUB_TOKEN="${{ inputs.github_token }}"
+        echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
+        CLA_TOKEN="${{ inputs.cla_assistant_token}}"
+        echo "PERSONAL_ACCESS_TOKEN=${CLA_TOKEN}" >> $GITHUB_ENV
     - name: "CLA Check"
       if: "(github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'"
       uses: "cla-assistant/github-action@v2.1.3-beta"
-      env:
-        GITHUB_TOKEN: "${{ inputs.github_token }}"
-        PERSONAL_ACCESS_TOKEN: "${{ inputs.cla_assistant_token }}"
       with:
         remote-organization-name: "authzed"
         remote-repository-name: "cla"


### PR DESCRIPTION
This adds a step to persist the secrets into the environment so that no
matter what happens in the CLA Assistant action, the values should be
there.