### PR TITLE
golangci-lint: drop skip go install arg

### DIFF
--- a/golangci-lint/action.yaml
+++ b/golangci-lint/action.yaml
@@ -13,6 +13,5 @@ runs:
       with:
         working-directory: "${{ inputs.working_directory }}"
         version: "v1.45"
-        skip-go-installation: true
         skip-pkg-cache: true
         skip-build-cache: false


### PR DESCRIPTION
This was removed in golangci/golangci-lint-action#403