### PR TITLE
Move golangci-lint to 1.48

### DIFF
--- a/golangci-lint/action.yaml
+++ b/golangci-lint/action.yaml
@@ -12,6 +12,6 @@ runs:
     - uses: "golangci/golangci-lint-action@v3"
       with:
         working-directory: "${{ inputs.working_directory }}"
-        version: "v1.47"
+        version: "v1.48"
         skip-pkg-cache: true
         skip-build-cache: false


### PR DESCRIPTION
Got:
```
  panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
```
with 1.47 on go 1.19