### PR TITLE
bump codeql to v2

### DIFF
--- a/codeql/action.yaml
+++ b/codeql/action.yaml
@@ -4,8 +4,8 @@ description: "This action analyzes the working tree with CodeQL."
 runs:
   using: "composite"
   steps:
-    - uses: "github/codeql-action/init@v1"
+    - uses: "github/codeql-action/init@v2"
       with:
         languages: "${{ matrix.language }}"
-    - uses: "github/codeql-action/autobuild@v1"
-    - uses: "github/codeql-action/analyze@v1"
+    - uses: "github/codeql-action/autobuild@v2"
+    - uses: "github/codeql-action/analyze@v2"


### PR DESCRIPTION
https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/