### PR TITLE
fix buf rate limits

### DIFF
--- a/buf-generate/action.yaml
+++ b/buf-generate/action.yaml
@@ -15,10 +15,9 @@ runs:
   using: "composite"
   steps:
     - uses: "bufbuild/buf-setup-action@v1"
-      env:
-        GITHUB_TOKEN: "${{ inputs.github_token }}"
       with:
         version: "${{ inputs.version }}"
+        github_token: "${{ inputs.github_token }}"
     - name: "Generate & Diff Protos"
       shell: "bash"
       run: "./buf.gen.yaml"


### PR DESCRIPTION
our builds sometimes fail due to Actions rate limits via buf action.

This changes the action to follow what's specified in the docs:

https://buf.build/docs/ci-cd/github-actions/#buf-setup

>Optionally, you can supply a github_token input so that any GitHub API requests are authenticated. This may prevent rate limit issues when running on GitHub hosted runners:

>```steps:
>  - uses: actions/checkout@v2
>  - uses: bufbuild/buf-setup-action@v1
>    with:
>      github_token: ${{ github.token }}
>```

![image](https://github.com/authzed/actions/assets/6774726/61c2f302-42dc-4b36-88fe-9d9844510415)
