### PR TITLE
Update action.yaml

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -9,6 +9,7 @@ inputs:
     description: "Path to the go.mod or go.work file."
   cache-dependency-path:
     description: "Used to specify the path to a dependency file - go.sum"
+    default: "**/go.sum"
   working_directory:
     description: "The directory with the root of the project"
     default: "."


### PR DESCRIPTION
it seems like setup-go caching is not working properly because it infers incorrectly the position of `go.sum`. This sets it to a sane default that should work in most cases

See https://github.com/actions/setup-go/issues/427#issuecomment-1946115668