### PR TITLE
Reverse order of args in go-license-check

### DIFF
--- a/go-license-check/action.yaml
+++ b/go-license-check/action.yaml
@@ -33,4 +33,4 @@ runs:
     - name: "Run Go Licenses Check"
       shell: "bash"
       working-directory: "${{ inputs.working_directory }}"
-      run: "go-licenses check --include_tests ./... --ignore ${{ inputs.ignore }}"
+      run: "go-licenses check --include_tests --ignore ${{ inputs.ignore }} ./..."


### PR DESCRIPTION
## Description
We started running into lint failures from `go-license-check`. [This comment](https://github.com/google/go-licenses/issues/128#issuecomment-1927301121) indicates that reversing the order of args might help here.

## Changes
* Reverse order of args per github comment
## Testing
Review.