### PR TITLE
golangci-lint: Bump to v1.61.0

### DIFF
--- a/golangci-lint/action.yaml
+++ b/golangci-lint/action.yaml
@@ -17,6 +17,6 @@ runs:
       with:
         working-directory: "${{ inputs.working_directory }}"
         args: "${{ inputs.args }}"
-        version: "v1.57.2"
+        version: "v1.61.0"
         skip-pkg-cache: true
         skip-build-cache: false


### PR DESCRIPTION
We moved to Go 1.23 in https://github.com/authzed/actions/pull/65 and golangci-lint was timing out.