### PR TITLE
Make 1.23.5 available to runner

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
   go-version:
     description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
-    default: "1.23.4"
+    default: "1.23.5"
   go-version-file:
     description: "Path to the go.mod or go.work file."
   cache-dependency-path:


### PR DESCRIPTION
## Description
1.23.5 is out, and it's required because it fixes a vuln. This makes it the default.

## Changes
Bump default to 1.23.5.

## Testing
Review.