### PR TITLE
golangci-lint: Bump to v1.64.5

### DIFF
--- a/golangci-lint/action.yaml
+++ b/golangci-lint/action.yaml
@@ -17,6 +17,6 @@ runs:
       with:
         working-directory: "${{ inputs.working_directory }}"
         args: "${{ inputs.args }}"
-        version: "v1.61.0"
+        version: "v1.64.5"
         skip-pkg-cache: true
         skip-build-cache: false


### PR DESCRIPTION
Updating to latest golangci-lint release.