### PR TITLE
setup-go: also go mod download magefiles if present

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -32,3 +32,8 @@ runs:
       working-directory: "${{ inputs.working_directory }}"
       shell: "bash"
       run: "go mod download"
+    - name: "Run Magefiles Go Mod Download"
+      if: "inputs.download == 'true'"
+      working-directory: "${{ inputs.working_directory }}"
+      shell: "bash"
+      run: "[ -d './magefiles' ] && (cd './magefiles' && go mod download -json)"

--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -36,4 +36,4 @@ runs:
       if: "inputs.download == 'true'"
       working-directory: "${{ inputs.working_directory }}"
       shell: "bash"
-      run: "[ -d './magefiles' ] && (cd './magefiles' && go mod download -json)"
+      run: "[ -d './magefiles' ] && (cd './magefiles' && go mod download)"


### PR DESCRIPTION
since many authzed repos rely on mage for commands, and it lives typically in a isolated /magefiles module, it wasn't caching go mod download for it, making CI pipeline slower