### PR TITLE
Bump golangci-lint action version number

### DIFF
--- a/golangci-lint/action.yaml
+++ b/golangci-lint/action.yaml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: "golangci/golangci-lint-action@v4"
+    - uses: "golangci/golangci-lint-action@v8"
       with:
         working-directory: "${{ inputs.working_directory }}"
         args: "${{ inputs.args }}"


### PR DESCRIPTION
## Description
This error is likely happening because the action we're using is _old_: https://github.com/authzed/config/actions/runs/15054427000/job/42316856888?pr=1918

This bumps that version number.

## Changes
* Bump the version
## Testing
Review.