### PR TITLE
Fix default golangci-lint version

### DIFF
--- a/golangci-lint/action.yaml
+++ b/golangci-lint/action.yaml
@@ -17,6 +17,6 @@ runs:
       with:
         working-directory: "${{ inputs.working_directory }}"
         args: "${{ inputs.args }}"
-        version: "v1.64.5"
+        version: "v2.1.6"
         skip-pkg-cache: true
         skip-build-cache: false


### PR DESCRIPTION
## Description
Followon to #86. The new versions of the action don't support old versions of the linter.

## Changes
* Bump default version to current
## Testing
Review.