### PR TITLE
Move go builds to 1.24.6

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
   go-version:
     description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
-    default: "1.24.4"
+    default: "1.24.6"
   go-version-file:
     description: "Path to the go.mod or go.work file."
   cache-dependency-path:


### PR DESCRIPTION
Fixes a reported vuln in the Go standard lib