### PR TITLE
chore: update golang linter to 2.5.0

### DIFF
--- a/golangci-lint/action.yaml
+++ b/golangci-lint/action.yaml
@@ -17,4 +17,4 @@ runs:
       with:
         working-directory: "${{ inputs.working_directory }}"
         args: "${{ inputs.args }}"
-        version: "v2.4.0"
+        version: "v2.5.0"


### PR DESCRIPTION
See https://github.com/golangci/golangci-lint/releases/tag/v2.5.0