### PR TITLE
Upgrade golang version to take CVE fix

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
   go-version:
     description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
-    default: "1.25.1"
+    default: "1.25.3"
   go-version-file:
     description: "Path to the go.mod or go.work file."
   cache-dependency-path:


### PR DESCRIPTION
## Description
Part of fixing https://pkg.go.dev/vuln/GO-2025-4007 across our repos.

## Changes
* Bump golang version to 1.25.3
## Testing
Review.