### PR TITLE
Remove golang version constraint

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -2,9 +2,6 @@
 name: "Setup Go environment"
 description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
-  go-version:
-    description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
-    default: "1.25.3"
   go-version-file:
     description: "Path to the go.mod or go.work file."
   cache-dependency-path:
@@ -23,7 +20,6 @@ runs:
   steps:
     - uses: "actions/setup-go@v5"
       with:
-        go-version: "${{ inputs.go-version }}"
         go-version-file: "${{ inputs.go-version-file }}"
         cache-dependency-path: "${{ inputs.cache-dependency-path }}"
         cache: "true"


### PR DESCRIPTION
## Description
Bumping this version mostly ends up being toil on our part: every time there's a CVE in golang, we have to bump this as well as all of the versions in each of the repos.

Beyond that, this is just the tooling version - it's not the version used by the target project, which is pinned in the `go.mod` for that project.

Getting rid of this constraint should reduce toil without exposing us to security issues.

## Changes
* Remove version constraint in `setup-go` action
## Testing
Review.