### PR TITLE
Use our fork of markdown-lint

### DIFF
--- a/markdown-lint/action.yaml
+++ b/markdown-lint/action.yaml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: "avto-dev/markdown-lint@v1"
+    - uses: "authzed/markdown-lint-action@v1"
       with:
         config: "${{ inputs.working_directory }}/.markdownlint.yaml"
         args: "${{ inputs.working_directory }} ${{ inputs.args }}"


### PR DESCRIPTION
## Description
The upstream isn't maintained and doesn't support arm builds. This gets on our fork, which will.

## Changes
* Use our fork
## Testing
Review.