### PR TITLE
chore: update golangci-lint to be compatible with v1.26

### DIFF
--- a/golangci-lint/action.yaml
+++ b/golangci-lint/action.yaml
@@ -17,4 +17,4 @@ runs:
       with:
         working-directory: "${{ inputs.working_directory }}"
         args: "${{ inputs.args }}"
-        version: "v2.5.0"
+        version: "v2.11.1"


### PR DESCRIPTION
## Description
Should fix this issue: https://github.com/authzed/internal/actions/runs/22790605650/job/66116338892?pr=10199

Will also likely come with a bunch of lint failures that we'll need to fix across our repos, but that was going to happen anyway.

## Changes
* bump golangci-lint version
## Testing
Review.