### PR TITLE
fix: read Go version from go.mod instead of hardcoding

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -3,10 +3,10 @@ name: "Setup Go environment"
 description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
   go-version:
-    description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
-    default: "1.26.1"
+    description: "The Go version to download (if necessary) and use. Supports semver spec and ranges. If empty, the version is read from go-version-file."
   go-version-file:
     description: "Path to the go.mod or go.work file."
+    default: "go.mod"
   cache-dependency-path:
     description: "Used to specify the path to a dependency file - go.sum"
     default: "**/go.sum"


### PR DESCRIPTION
## Summary
- Removes the hardcoded `go-version` default (`1.26.1`) from `setup-go/action.yaml`
- Defaults `go-version-file` to `go.mod` so the Go version is read from the project's `go.mod` automatically

Closes #122