### PR TITLE
Revert "fix: read Go version from go.mod instead of hardcoding (#123)"

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -3,10 +3,10 @@ name: "Setup Go environment"
 description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
   go-version:
-    description: "The Go version to download (if necessary) and use. Supports semver spec and ranges. If empty, the version is read from go-version-file."
+    description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
+    default: "1.26.1"
   go-version-file:
     description: "Path to the go.mod or go.work file."
-    default: "go.mod"
   cache-dependency-path:
     description: "Used to specify the path to a dependency file - go.sum"
     default: "**/go.sum"


### PR DESCRIPTION
This reverts commit 313a337f3c257453e4c8b82e83799b3ad8c8c170.
