### PR TITLE
fix: read Go version from go.mod with working_directory support

### DIFF
--- a/.github/workflows/test-setup-go.yaml
+++ b/.github/workflows/test-setup-go.yaml
@@ -1,0 +1,41 @@
+---
+name: "Test setup-go"
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "main"
+  pull_request:
+    paths: ["setup-go/**"]
+jobs:
+  test-default:
+    name: "Test - root directory"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "./setup-go"
+        with:
+          download: "false"
+      - run: "go version"
+
+  test-subdirectory:
+    name: "Test - subdirectory"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - run: "mkdir -p subproject && cp go.mod go.sum subproject/"
+      - uses: "./setup-go"
+        with:
+          working_directory: "./subproject"
+          download: "false"
+      - run: "go version"
+
+  test-explicit-version:
+    name: "Test - explicit go-version"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v6"
+      - uses: "./setup-go"
+        with:
+          go-version: "1.24"
+          download: "false"
+      - run: "go version"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/authzed/actions
+
+go 1.26.2

--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -3,10 +3,10 @@ name: "Setup Go environment"
 description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
   go-version:
-    description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
-    default: "1.26.2"
+    description: "The Go version to download (if necessary) and use. Supports semver spec and ranges. If empty, the version is read from go-version-file."
   go-version-file:
-    description: "Path to the go.mod or go.work file."
+    description: "Path to the go.mod or go.work file, relative to working_directory."
+    default: "go.mod"
   cache-dependency-path:
     description: "Used to specify the path to a dependency file - go.sum"
     default: "**/go.sum"
@@ -24,7 +24,7 @@ runs:
     - uses: "actions/setup-go@v6"
       with:
         go-version: "${{ inputs.go-version }}"
-        go-version-file: "${{ inputs.go-version-file }}"
+        go-version-file: "${{ !inputs.go-version && inputs.go-version-file && format('{0}/{1}', inputs.working_directory, inputs.go-version-file) || '' }}"
         cache-dependency-path: "${{ inputs.cache-dependency-path }}"
         cache: "true"
     - name: "Run Go Mod Download"


### PR DESCRIPTION
- Re-applies #123 with the fix for the `working_directory` issue that caused the revert in #124
- `actions/setup-go` resolves `go-version-file` relative to the repo root, so we now prepend `working_directory` to the path
- Adds CI test workflow covering root dir, subdirectory, and explicit version cases