### PR TITLE
chore: bump default Go to 1.26.5 for GO-2026-5856

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
   go-version:
     description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
-    default: "1.26.4"
+    default: "1.26.5"
   go-version-file:
     description: "Path to the go.mod or go.work file."
   cache-dependency-path:


### PR DESCRIPTION
Bumps the `setup-go` default Go version from 1.26.4 to 1.26.5 to pick up the fix for [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak in `crypto/tls`).

`govulncheck` now flags every repo built with go1.26.4 that touches TLS, failing `lint:go` CI jobs (e.g. authzed/tiger#1633). Since `actions/setup-go@v6` pins `GOTOOLCHAIN=local`, repos can't bump their `go` directive past 1.26.4 until this default is raised.

Same shape as #132.