### PR TITLE
INFRA-681: Pin setup-jsonnet default to v0.21.0

### DIFF
--- a/setup-jsonnet/action.yaml
+++ b/setup-jsonnet/action.yaml
@@ -3,9 +3,9 @@ name: "Setup Go Jsonnet"
 description: "Download and install Go Jsonnet"
 inputs:
   version:
-    description: "Version of Jsonnet to install. Default: `latest`"
+    description: "Version of Jsonnet to install. Default: `v0.21.0`"
     required: false
-    default: "latest"
+    default: "v0.21.0"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Summary
- change the `setup-jsonnet` default from `latest` to v0.21.0
- keep callers without an explicit version from drifting between CI runs

## Testing
- `git diff --check`

## Related
- authzed/config#5534
- authzed/internal#11583
- [INFRA-681](https://linear.app/authzed/issue/INFRA-681/update-jsonnet-and-tanka-runtime-versions)