### PR TITLE
chore: bump default Go to 1.26.6 for seven stdlib advisories

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -4,7 +4,7 @@ description: "Setup a Go environment and add it to the PATH (with caching!)"
 inputs:
   go-version:
     description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
-    default: "1.26.5"
+    default: "1.26.6"
   go-version-file:
     description: "Path to the go.mod or go.work file."
   cache-dependency-path:


### PR DESCRIPTION
## Problem

govulncheck finds seven vulnerabilities in the Go 1.26.5 standard library. Go 1.26.6 corrects all seven:

GO-2026-5026, GO-2026-5972, GO-2026-6088, GO-2026-6089, GO-2026-6090, GO-2026-6091, GO-2026-6218.

`actions/setup-go` sets `GOTOOLCHAIN=local`. A runner therefore cannot fetch a newer toolchain. If a repository raises its `go` directive to 1.26.6, the job fails with this message:

```
go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
```